### PR TITLE
Add UNIX dgram sockets transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Janode is a Node.js, browser compatible, adapter for the [Janus WebRTC server](https://github.com/meetecho/janus-gateway).
 
-Internally uses WebSockets to connect to Janus.
+Internally uses WebSockets or Unix DGRAM Sockets to connect to Janus.
 
 The library wraps the Janus core API, the Janus Admin API and some of the most popular plugins APIs.
 
@@ -73,6 +73,32 @@ const admin = await Janode.connect({
 // Get the list of active sessions
 const data = await admin.listSessions();
 
+```
+
+## Switching to other transports
+
+The kind of transport used for a connection depends on the protocol/scheme defined in the `url` field of the configuration.
+
+```js
+/* Use UNIX DGRAM Sockets */
+const admin = await Janode.connect({
+  is_admin: true,
+  address: {
+    url: 'unix://tmp/janusapi',
+    apisecret: 'secret'
+  }
+});
+```
+
+```js
+/* Use WebSockets */
+const admin = await Janode.connect({
+  is_admin: true,
+  address: {
+    url: 'ws://127.0.0.1:7188/',
+    apisecret: 'secret'
+  }
+});
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The kind of transport used for a connection depends on the protocol/scheme defin
 const admin = await Janode.connect({
   is_admin: true,
   address: {
-    url: 'unix://tmp/janusapi',
+    url: 'file://tmp/janusapi',
     apisecret: 'secret'
   }
 });

--- a/examples/browser/bundle.sh
+++ b/examples/browser/bundle.sh
@@ -16,7 +16,9 @@ cat <<EOF > app.js
 module.exports = { Janode: require('../../src/janode.js'), EchoTestPlugin: require('../../src/plugins/echotest-plugin.js') };
 EOF
 
-browserify app.js --standalone $EXPORTED_OBJECT -o $BUILD_DIR/$BUNDLE_FILENAME --dg=false
+browserify app.js --standalone $EXPORTED_OBJECT -o $BUILD_DIR/$BUNDLE_FILENAME \
+    --dg=false \
+    --ignore "../../src/transport-unix.js"
 
 cp ./app/*.* $DEPLOY_DIR
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,17 +10,20 @@
       "license": "ISC",
       "dependencies": {
         "isomorphic-ws": "^4.0.1",
-        "unix-dgram": "^2.0.4",
         "ws": "^8.0.0"
       },
       "engines": {
         "node": ">=12"
+      },
+      "optionalDependencies": {
+        "unix-dgram": "^2.0.4"
       }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -28,7 +31,8 @@
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
@@ -41,13 +45,15 @@
     "node_modules/nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "node_modules/unix-dgram": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
       "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "bindings": "^1.3.0",
         "nan": "^2.13.2"
@@ -57,9 +63,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
+      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -82,6 +88,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
       "requires": {
         "file-uri-to-path": "1.0.0"
       }
@@ -89,7 +96,8 @@
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "isomorphic-ws": {
       "version": "4.0.1",
@@ -100,21 +108,23 @@
     "nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "optional": true
     },
     "unix-dgram": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
       "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
+      "optional": true,
       "requires": {
         "bindings": "^1.3.0",
         "nan": "^2.13.2"
       }
     },
     "ws": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
+      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
       "requires": {}
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,25 @@
       "license": "ISC",
       "dependencies": {
         "isomorphic-ws": "^4.0.1",
+        "unix-dgram": "^2.0.4",
         "ws": "^8.0.0"
       },
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
@@ -22,6 +36,24 @@
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "peerDependencies": {
         "ws": "*"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+    },
+    "node_modules/unix-dgram": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
+      "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      },
+      "engines": {
+        "node": ">=0.10.48"
       }
     },
     "node_modules/ws": {
@@ -46,11 +78,38 @@
     }
   },
   "dependencies": {
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
       "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
       "requires": {}
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+    },
+    "unix-dgram": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.4.tgz",
+      "integrity": "sha512-7tpK6x7ls7J7pDrrAU63h93R0dVhRbPwiRRCawR10cl+2e1VOvF3bHlVJc6WI1dl/8qk5He673QU+Ogv7bPNaw==",
+      "requires": {
+        "bindings": "^1.3.0",
+        "nan": "^2.13.2"
+      }
     },
     "ws": {
       "version": "8.2.3",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "src/plugins/*.js"
   ],
   "dependencies": {
-    "ws": "^8.0.0",
-    "isomorphic-ws": "^4.0.1"
+    "isomorphic-ws": "^4.0.1",
+    "unix-dgram": "^2.0.4",
+    "ws": "^8.0.0"
   },
   "engines": {
     "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,10 @@
   ],
   "dependencies": {
     "isomorphic-ws": "^4.0.1",
-    "unix-dgram": "^2.0.4",
     "ws": "^8.0.0"
+  },
+  "optionalDependencies": {
+    "unix-dgram": "^2.0.4"
   },
   "engines": {
     "node": ">=12"

--- a/src/connection.js
+++ b/src/connection.js
@@ -13,6 +13,7 @@ const LOG_NS = '[connection.js]';
 const { getNumericID, checkUrl, newIterator } = require('./utils/utils.js');
 const { JANODE, JANUS, isResponseData, isErrorData } = require('./protocol.js');
 const WsTransport = require('./transport-ws.js');
+const UnixTransport = require('./transport-unix.js');
 const JanodeSession = require('./session.js');
 const TransactionManager = require('./tmanager.js');
 
@@ -106,6 +107,9 @@ class Connection extends EventEmitter {
       /* Check the protocol to define the kind of transport */
       if (checkUrl(server_config.getAddress()[0].url, ['ws', 'wss', 'ws+unix', 'wss+unix'])) {
         transport = new WsTransport(this);
+      }
+      if (checkUrl(server_config.getAddress()[0].url, ['file'])) {
+        transport = new UnixTransport(this);
       }
       if (transport) this._transport = transport;
     } catch (error) {

--- a/src/transport-unix.js
+++ b/src/transport-unix.js
@@ -1,0 +1,330 @@
+'use strict';
+
+/**
+ * This module contains the Unix Sockets transport implementation.
+ * @module transport-unix
+ * @private
+ */
+
+const { Buffer } = require('buffer');
+const { unlinkSync } = require('fs');
+
+/* External dependency with Unix dgram sockets implementation */
+const unix = require('unix-dgram');
+
+const Logger = require('./utils/logger.js');
+const LOG_NS = '[transport-unix.js]';
+const { delayOp } = require('./utils/utils.js');
+
+/**
+ * Class representing a connection through Unix dgram sockets transport.<br>
+ *
+ * In case of failure a connection will be retried according to the configuration (time interval and
+ * times to attempt). At every attempt, if multiple addresses are available for Janus, the next address
+ * will be tried. An error will be raised only if the maxmimum number of attempts have been reached.<br>
+ *
+ * @private
+ */
+class TransportUnix {
+  /**
+   * Create a connection through Unix dgram socket.
+   *
+   * @param {module:connection~Connection} connection - The parent Janode connection
+   */
+  constructor(connection) {
+    /**
+     * The parent  Janode connection.
+     *
+     * @type {module:connection~Connection}
+     */
+    this._connection = connection;
+
+    /**
+     * The internal Unix Socket.
+     *
+     * @type {module:unix-dgram~Socket}
+     */
+    this._socket = null;
+
+    /**
+     * The local file to bind the socket to.
+     */
+    this._local_bind = `/tmp/.janode-${connection.id}`;
+
+    /**
+     * Internal counter for connection attempts.
+     *
+     * @type {number}
+     */
+    this._attempts = 0;
+
+    /**
+     * A boolean flag indicating that the connection is being opened.
+     *
+     * @type {boolean}
+     */
+    this._opening = false;
+
+    /**
+     * A boolean flag indicating that the connection has been opened.
+     *
+     * @type {boolean}
+     */
+    this._opened = false;
+
+    /**
+     * A boolean flag indicating that the connection is being closed.
+     *
+     * @type {boolean}
+     */
+    this._closing = false;
+
+    /**
+     * A boolean flag indicating that the connection has been closed.
+     *
+     * @type {boolean}
+     */
+    this._closed = false; // true if socket has been closed after being opened
+
+    /**
+     * A numerical identifier assigned for logging purposes.
+     *
+     * @type {number}
+     */
+    this.id = connection.id;
+
+    /**
+     * A more descriptive, not unique string (used for logging).
+     *
+     * @type {string}
+     */
+    this.name = `[${this.id}]`;
+  }
+
+  /**
+   * Initialize the internal socket.
+   *
+   * @returns {Promise<module:connection~Connection>}
+   */
+  async _initUnixSocket() {
+    Logger.info(`${LOG_NS} ${this.name} trying connection with ${this._connection._address_iterator.currElem().url}`);
+
+    return new Promise((resolve, reject) => {
+      let socket;
+
+      let connected = false;
+      let bound = false;
+
+      try {
+        socket = unix.createSocket('unix_dgram');
+      } catch (error) {
+        Logger.error(`${LOG_NS} ${this.name} unix socket create error (${error.message})`);
+        reject(error);
+        return;
+      }
+
+      socket.on('error', error => {
+        Logger.error(`${LOG_NS} ${this.name} unix socket error (${error.message})`);
+        if (error.errno < 0) {
+          this._close();
+        }
+        reject(error);
+      });
+
+      socket.on('connect', _ => {
+        Logger.info(`${LOG_NS} ${this.name} unix socket connected`)
+        connected = true;
+        if (bound && connected) resolve(this);
+      });
+
+      socket.on('listening', _ => {
+        Logger.info(`${LOG_NS} ${this.name} unix socket bound`);
+        /* Resolve the promise and return this connection */
+        bound = true;
+        socket.connect(this._connection._address_iterator.currElem().url.split('file://')[1]);
+        if (bound && connected) resolve(this);
+      });
+
+      socket.on('message', buf => {
+        const data = buf.toString();
+        Logger.debug(`${LOG_NS} ${this.name} <unix RCV OK> ${data}`);
+        this._connection._handleMessage(JSON.parse(data));
+      });
+
+      socket.on('writable', _ => {
+        Logger.warn(`${LOG_NS} ${this.name} unix socket writable notification`);
+      });
+
+      socket.on('congestion', _buf => {
+        Logger.warn(`${LOG_NS} ${this.name} unix socket congestion notification`);
+      });
+
+      this._socket = socket;
+
+      try { unlinkSync(this._local_bind); } catch (error) { }
+      socket.bind(this._local_bind);
+    });
+  }
+
+  /**
+   * Internal helper to open a unix socket connection.
+   * In case of error retry the connection with another address from the available pool.
+   * If maximum number of attempts is reached, throws an error.
+   *
+   * @returns {module:unix-dgram~Socket} The unix socket
+   */
+  async _attemptOpen() {
+    /* Reset status at every attempt */
+    this._opened = false;
+    this._closing = false;
+    this._closed = false;
+
+    try {
+      const conn = await this._initUnixSocket();
+      this._opening = false;
+      this._opened = true;
+      return conn;
+    }
+    catch (error) {
+      /* In case of error notifies the user, but try with another address */
+      this._attempts++;
+      /* Get the max number of attempts from the configuration */
+      if (this._attempts >= this._connection._config.getMaxRetries()) {
+        this._opening = false;
+        const err = new Error('attempt limit exceeded');
+        Logger.error(`${LOG_NS} ${this.name} socket connection failed, ${err.message}`);
+        throw error;
+      }
+      Logger.error(`${LOG_NS} ${this.name} socket connection failed, will try again in ${this._connection._config.getRetryTimeSeconds()} seconds...`);
+      /* Wait an amount of seconds specified in the configuration */
+      await delayOp(this._connection._config.getRetryTimeSeconds() * 1000);
+      /* Make shift the circular iterator */
+      this._connection._address_iterator.nextElem();
+      return this._attemptOpen();
+    }
+  }
+
+  _close() {
+    if (!this._socket) return;
+    Logger.info(`${LOG_NS} ${this.name} closing unix transport`);
+    try {
+      this._socket.close();
+    } catch (error) {
+      Logger.error(`${LOG_NS} ${this.name} error while closing unix socket (${error.message})`);
+    }
+
+    try {
+      unlinkSync(this._local_bind);
+    } catch (error) {
+      Logger.error(`${LOG_NS} ${this.name} error while unlinking fd (${error.message})`);
+    }
+    /* removeAllListeners is only supported on the node ws module */
+    if (typeof this._socket.removeAllListeners === 'function') this._socket.removeAllListeners();
+    this._socket = null;
+    this._connection._signalClose(this._closing);
+    this._closing = false;
+    this._closed = true;
+  }
+
+  /**
+   * Open a transport connection. This is called from parent connection.
+   *
+   * @returns {Promise<module:connection~Connection>} A promise resolving with the Janode connection
+   */
+  async open() {
+    /* Check the flags before attempting a connection */
+    let error;
+    if (this._opening) error = new Error('unable to open, unix socket is already being opened');
+    else if (this._opened) error = new Error('unable to open, unix socket has already been opened');
+    else if (this._closed) error = new Error('unable to open, unix socket has already been closed');
+
+    if (error) {
+      Logger.error(`${LOG_NS} ${this.name} ${error.message}`);
+      throw error;
+    }
+
+    /* Set the starting status */
+    this._opening = true;
+    this._attempts = 0;
+
+    /* Use internal helper */
+    return this._attemptOpen();
+  }
+
+  /**
+   * Get the remote Janus hostname.
+   * It is called from the parent connection.
+   *
+   * @returns {string} The hostname of the Janus server
+   */
+  getRemoteHostname() {
+    if (this._opened) {
+      return (this._connection._address_iterator.currElem().url.split('file://')[1]);
+    }
+    return null;
+  }
+
+  /**
+   * Gracefully close the connection.
+   * It is called from the parent connection.
+   *
+   * @returns {Promise<void>}
+   */
+  async close() {
+    /* Check the status flags before */
+    let error;
+    if (!this._opened) error = new Error('unable to close, unix socket has never been opened');
+    else if (this._closing) error = new Error('unable to close, unix socket is already being closed');
+    else if (this._closed) error = new Error('unable to close, unix socket has already been closed');
+
+    if (error) {
+      Logger.error(`${LOG_NS} ${this.name} ${error.message}`);
+      throw error;
+    }
+
+    this._closing = true;
+
+    return this._close();
+  }
+
+  /**
+   * Send a request from this connection.
+   * It is called from the parent connection.
+   *
+   * @param {object} request - The request to be sent
+   * @returns {Promise<object>} A promise resolving with a response from Janus
+   */
+  async send(request) {
+    /* Check connection status */
+    let error;
+    if (!this._opened) error = new Error('unable to send request because unix socket has not been opened');
+    else if (this._closed) error = new Error('unable to send request because unix socket has been closed');
+
+    if (error) {
+      Logger.error(`${LOG_NS} ${this.name} ${error.message}`);
+      throw error;
+    }
+
+    /* Stringify the message */
+    const string_req = JSON.stringify(request);
+    const buf = Buffer.from(string_req, 'utf-8');
+
+    return new Promise((resolve, reject) => {
+      this._socket.send(buf, error => {
+        if (error) {
+          Logger.error(`${LOG_NS} ${this.name} unix socket send error (${error.message})`);
+          if (error.errno < 0) {
+            this._close();
+          }
+          reject(error);
+          return;
+        }
+        Logger.debug(`${LOG_NS} ${this.name} <unix SND OK> ${string_req}`);
+        resolve();
+      });
+    });
+  }
+
+}
+
+module.exports = TransportUnix;


### PR DESCRIPTION
This PR adds the [UNIX sockets transport](https://janus.conf.meetecho.com/docs/rest.html#unix) to Janode.
The UNIX socket transport is a more efficient way of establishing connections with Janus when Janode is co-located on the host OS, since in this case the adapter and the server will communicate through Inter-Process Communication (IPC) using a UNIX socket without traversing the network stack.

When dealing with UNIX sockets Janus [only supports](https://github.com/meetecho/janus-gateway/blob/v0.11.5/conf/janus.transport.pfunix.jcfg.sample#L12) `SOCK_SEQPACKET` (default) and `SOCK_DGRAM` because those modes preserve message boundaries thus keeping both the implementation and the communication simple.
On the other hand, node only offers `SOCK_STREAM` for IPC ([net.Socket Class](https://nodejs.org/api/net.html#class-netsocket)) on Linux, so it is impossibile to rely on native node modules.

Since we didn't manage to find any external library implementing  `SOCK_SEQPACKET` IPC, we've ended up using [unix-dgram-socket](https://github.com/ulwanski/unix-dgram-socket). This library has a simple C++ `SOCK_DGRAM` implementation with js code binding to it.

### Caveats when using SOCK_DGRAM IPC
`SOCK_DGRAM` IPC means that the socket is connection-less, thus:
1) the socket on Janode will bind to a local file, needed for handling responses and located at `/tmp/.janode-someid`
2) there is no `close` notification, so the liveness of the channel must be checked with a higher level mechanism (such as session keep-alives). Any error when sending a message will trigger a connection tear-down.

### How to use it
In order to use this transport edit the  `janus.transport.pfunix.jcfg` Janus configuration:
1) enable the transport
2) set a path for the server socket (e.g. `/tmp/janusapi`)
3) set SOCK_DGRAM in the socket type

Then edit the Janode app configuration, setting a Janus url that starts with the `file://` scheme and matches the server socket path:
```js
{
    address: {
      url: 'file:///tmp/janusapi',
      apisecret: 'secret'
    },
}
```

### Difference with WebSockets over UNIX sockets
Another chance to indirectly rely on UNIX sockets is to use the WebSocket transport providing a scheme `ws+unix://` in the janus url.
```js
{
    address: {
      url: 'ws+unix:///tmp/ws.sock',
      apisecret: 'secret'
    },
}
```
Ref https://github.com/meetecho/janus-gateway/pull/2620.
In that case everything will work as normal WebSockets on both client and server but the communication will not happen on top of TCP/IP but over UNIX sockets (probably `SOCK_STREAM`), preserving the WebSockets framing.
Raw UNIX sockets transport will instead push JSON datagrams from/to the sockets without any other framing.

### Skip dependency installation
If by any reason you do not want to install the unix-dgram dependency on your system, just build janode without optional dependencies
```bash
npm install --no-optional
``` 

### Supported platforms
This PR has been tested on Linux only.
Windows is not supported by the third-party library (installation will not fail, the compiled module will only contain an empty stub).

### Browsers
Of course this transport does not work on browsers.
We have updated the sample `bundle.sh` script to ignore the `transport-unix.js` file and replace it with an empty blob.