### PR TITLE
add host_family to startForward

### DIFF
--- a/src/plugins/audiobridge-plugin.js
+++ b/src/plugins/audiobridge-plugin.js
@@ -732,13 +732,15 @@ class AudioBridgeHandle extends Handle {
    * @param {string} [params.secret] - The optional secret needed to manage the room
    * @returns {Promise<module:audiobridge-plugin~AUDIOBRIDGE_EVENT_RTP_FWD>}
    */
-  async startForward({ room, always, host, audio_port, ssrc, ptype, codec, group, secret }) {
+  async startForward({ room, always, host, host_family, audio_port, ssrc, ptype, codec, group, secret }) {
     const body = {
       request: REQUEST_RTP_FWD_START,
       room,
     };
     if (typeof always === 'boolean') body.always_on = always;
     if (typeof host === 'string') body.host = host;
+    if (typeof host_family === 'string' &&
+      (host_family.toLowerCase() === 'ipv4' || host_family.toLowerCase() === 'ipv6')) body.host_family = host_family.toLowerCase();
     if (typeof audio_port === 'number') body.port = audio_port;
     if (typeof ssrc === 'number') body.ssrc = ssrc;
     if (typeof ptype === 'number') body.ptype = ptype;

--- a/src/plugins/audiobridge-plugin.js
+++ b/src/plugins/audiobridge-plugin.js
@@ -724,6 +724,7 @@ class AudioBridgeHandle extends Handle {
    * @param {number|string} params.room - The involved room
    * @param {boolean} [params.always] - Whether silence should be forwarded when the room is empty
    * @param {string} params.host - The host to forward to
+   * @param {string} params.host_family - ipv4|ipv6; by default, first family returned by DNS request
    * @param {number} params.audio_port - The port to forward to
    * @param {number} [params.ssrc] - The SSRC to use to use when forwarding
    * @param {number} [params.ptype] - The payload type to use to use when forwarding
@@ -739,8 +740,7 @@ class AudioBridgeHandle extends Handle {
     };
     if (typeof always === 'boolean') body.always_on = always;
     if (typeof host === 'string') body.host = host;
-    if (typeof host_family === 'string' &&
-      (host_family.toLowerCase() === 'ipv4' || host_family.toLowerCase() === 'ipv6')) body.host_family = host_family.toLowerCase();
+    if (typeof host_family === 'string') body.host_family = host_family;
     if (typeof audio_port === 'number') body.port = audio_port;
     if (typeof ssrc === 'number') body.ssrc = ssrc;
     if (typeof ptype === 'number') body.ptype = ptype;

--- a/src/plugins/audiobridge-plugin.js
+++ b/src/plugins/audiobridge-plugin.js
@@ -724,7 +724,7 @@ class AudioBridgeHandle extends Handle {
    * @param {number|string} params.room - The involved room
    * @param {boolean} [params.always] - Whether silence should be forwarded when the room is empty
    * @param {string} params.host - The host to forward to
-   * @param {string} params.host_family - ipv4|ipv6; by default, first family returned by DNS request
+   * @param {string} [params.host_family] - ipv4|ipv6; by default, first family returned by DNS request
    * @param {number} params.audio_port - The port to forward to
    * @param {number} [params.ssrc] - The SSRC to use to use when forwarding
    * @param {number} [params.ptype] - The payload type to use to use when forwarding


### PR DESCRIPTION
okay, this should be a clean request.

Just wanted to add host_family to the startForward request.

any reason why it was left out?