### PR TITLE
videoroom: add "admin_key" parameter to list API

### DIFF
--- a/src/plugins/videoroom-plugin.js
+++ b/src/plugins/videoroom-plugin.js
@@ -1265,9 +1265,10 @@ class VideoRoomHandle extends Handle {
    * @param {number|string} params.feed - The feed identifier for the forwarder to stop (must be published)
    * @param {number|string} params.stream - The forwarder identifier as returned by the start forward API
    * @param {string} [params.secret] - The secret needed for managing the room
+   * @param {string} [params.admin_key] - The admin key needed for invoking the API
    * @returns {Promise<module:videoroom-plugin~VIDEOROOM_EVENT_RTP_FWD_STOPPED>}
    */
-  async stopForward({ room, feed, stream, secret }) {
+  async stopForward({ room, feed, stream, secret, admin_key }) {
     const body = {
       request: REQUEST_RTP_FWD_STOP,
       room,
@@ -1275,6 +1276,7 @@ class VideoRoomHandle extends Handle {
       stream_id: stream,
     };
     if (typeof secret === 'string') body.secret = secret;
+    if (typeof admin_key === 'string') body.admin_key = admin_key;
 
     const response = await this.message(body);
     const { event, data: evtdata } = response._janode || {};

--- a/src/plugins/videoroom-plugin.js
+++ b/src/plugins/videoroom-plugin.js
@@ -1100,6 +1100,7 @@ class VideoRoomHandle extends Handle {
    * @param {boolean} [params.is_private] - Make the room private (hidden from listing)
    * @param {string} [params.secret] - The secret that will be used to modify the room
    * @param {string} [params.pin] - The pin needed to access the room
+   * @param {string} [params.admin_key] - The admin key needed for invoking the API
    * @param {number} [params.bitrate] - The bitrate cap that will be used for publishers
    * @param {boolean} [params.bitrate_cap] - Make the bitrate cap an insormountable limit
    * @param {number} [params.fir_freq] - The PLI interval in seconds
@@ -1116,7 +1117,7 @@ class VideoRoomHandle extends Handle {
    * @param {string} [params.h264_profile] - H264 specific profile to prefer
    * @returns {Promise<module:videoroom-plugin~VIDEOROOM_EVENT_CREATED>}
    */
-  async create({ room, description, max_publishers, permanent, is_private, secret, pin, bitrate,
+  async create({ room, description, max_publishers, permanent, is_private, secret, pin, admin_key, bitrate,
     bitrate_cap, fir_freq, audiocodec, videocodec, talking_events, talking_level_threshold, talking_packets_threshold,
     require_pvtid, require_e2ee, record, rec_dir, videoorient, h264_profile }) {
     const body = {
@@ -1129,6 +1130,7 @@ class VideoRoomHandle extends Handle {
     if (typeof is_private === 'boolean') body.is_private = is_private;
     if (typeof secret === 'string') body.secret = secret;
     if (typeof pin === 'string') body.pin = pin;
+    if (typeof admin_key === 'string') body.admin_key = admin_key;
     if (typeof bitrate === 'number') body.bitrate = bitrate;
     if (typeof bitrate_cap === 'boolean') body.bitrate_cap = bitrate_cap;
     if (typeof fir_freq === 'number') body.fir_freq = fir_freq;

--- a/src/plugins/videoroom-plugin.js
+++ b/src/plugins/videoroom-plugin.js
@@ -1071,12 +1071,15 @@ class VideoRoomHandle extends Handle {
   /**
    * List all the available rooms.
    *
+   * @param {object} params
+   * @param {string} [params.admin_key] - The admin key needed for invoking the API
    * @returns {Promise<module:videoroom-plugin~VIDEOROOM_EVENT_LIST>}
    */
-  async list() {
+  async list({ admin_key } = {}) {
     const body = {
       request: REQUEST_LIST_ROOMS,
     };
+    if (typeof admin_key === 'string') body.admin_key = admin_key;
 
     const response = await this.message(body);
     const { event, data: evtdata } = response._janode || {};


### PR DESCRIPTION
Before https://github.com/meetecho/janode/commit/28d019cd263602cfd35e8c118f8af88302c3a47b I didn't know it was possible to pass "admin_key" parameter to `list` requests to also get private records, interesting.
For the same reason I made the same change in videoroom, since it's also [supported by this plugin](https://github.com/meetecho/janus-gateway/blob/2ca1b587d0e0f8eb78f8fc9a5a5de225916dc3f3/src/plugins/janus_videoroom.c#L5021-L5033).

Thank you! 