### PR TITLE
Fix error: Videoroom error 429 Missing mandatory element (room)

### DIFF
--- a/examples/videoroom-ms/html/videoroom-ms-client.js
+++ b/examples/videoroom-ms/html/videoroom-ms-client.js
@@ -113,6 +113,7 @@ function configure({ feed, display, jsep, restart, streams }) {
   if (display) configureData.display = display;
   if (jsep) configureData.jsep = jsep;
   if (streams) configureData.streams = streams;
+  if (myRoom) configureData.room = myRoom;
   if (typeof restart === 'boolean') configureData.restart = restart;
 
   const configId = getId();


### PR DESCRIPTION
Fix error: Videoroom error 429 Missing mandatory element (room)