### PR TITLE
audiobridge: add support for the play_file API and events

### DIFF
--- a/src/plugins/audiobridge-plugin.js
+++ b/src/plugins/audiobridge-plugin.js
@@ -1157,7 +1157,7 @@ class AudioBridgeHandle extends Handle {
    * @param {string} [params.secret] - The optional secret needed to manage the room
    * @returns {Promise<module:audiobridge-plugin~AUDIOBRIDGE_EVENT_STOP_ALL_FILES_RESPONSE>}
    */
-  async stopAllFiles({ room, secret, file_id }) {
+  async stopAllFiles({ room, secret }) {
     const body = {
       request: REQUEST_STOP_ALL_FILES,
       room,


### PR DESCRIPTION
This PR adds support for the APIs revolving around playing files in the AudioBridge, so the `play_file`, `is_playing`, `stop_file` and `listannouncements` requests, plus the `announcement-started` and `announcement-stopped` events. <del>They're currently based on the `test/ab-configure-rtp` branch because that's what I was using for some internal testing, but they should work with the main branch as well if rebased.</del>