### PR TITLE
websockets: use native websockets and remove extra dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "1.7.2",
       "license": "ISC",
       "dependencies": {
-        "isomorphic-ws": "^4.0.1",
-        "unix-dgram": "^2.0.4",
-        "ws": "^8.0.0"
+        "unix-dgram": "^2.0.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.4.0",
@@ -19,7 +17,7 @@
         "globals": "^15.4.0"
       },
       "engines": {
-        "node": " >=18.18.0"
+        "node": " >=22.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -775,15 +773,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
     "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1121,27 +1110,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -36,9 +36,7 @@
     "src/plugins/*.js"
   ],
   "dependencies": {
-    "isomorphic-ws": "^4.0.1",
-    "unix-dgram": "^2.0.4",
-    "ws": "^8.0.0"
+    "unix-dgram": "^2.0.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.4.0",
@@ -46,7 +44,7 @@
     "globals": "^15.4.0"
   },
   "engines": {
-    "node": " >=18.18.0"
+    "node": " >=22.4.0"
   },
   "scripts": {
     "build": "npm install --omit=dev",

--- a/src/transport-ws.js
+++ b/src/transport-ws.js
@@ -6,10 +6,6 @@
  * @access private
  */
 
-/* Isomorphic implementation of WebSocket */
-/* It uses ws on Node and global.WebSocket in browsers */
-import WebSocket from 'isomorphic-ws';
-
 import Logger from './utils/logger.js';
 const LOG_NS = '[transport-ws.js]';
 import { delayOp } from './utils/utils.js';
@@ -19,11 +15,6 @@ const API_WS = 'janus-protocol';
 /* Janus Admin API ws subprotocol */
 const ADMIN_WS = 'janus-admin-protocol';
 
-/* Default ws ping interval */
-const PING_TIME_SECS = 10;
-/* Default pong wait timeout */
-const PING_TIME_WAIT_SECS = 5;
-
 /**
  * Class representing a connection through WebSocket transport.<br>
  *
@@ -31,7 +22,7 @@ const PING_TIME_WAIT_SECS = 5;
  * times to attempt). At every attempt, if multiple addresses are available for Janus, the next address
  * will be tried. An error will be raised only if the maxmimum number of attempts have been reached.<br>
  *
- * Internally uses WebSockets API to establish a connection with Janus and uses ws ping/pong as keepalives.<br>
+ * Internally uses WebSockets API to establish a connection with Janus.<br>
  *
  * @private
  */
@@ -91,12 +82,6 @@ class TransportWs {
      */
     this._closed = false; // true if websocket has been closed after being opened
 
-    /**
-     * The task of the peridic ws ping.
-     *
-     * @type {*}
-     */
-    this._ping_task = null;
 
     /**
      * A numerical identifier assigned for logging purposes.
@@ -134,8 +119,6 @@ class TransportWs {
       /* Register an "open" listener */
       ws.addEventListener('open', _ => {
         Logger.info(`${LOG_NS} ${this.name} websocket connected`);
-        /* Set the ping/pong task */
-        this._setPingTask(PING_TIME_SECS * 1000);
         /* Resolve the promise and return this connection */
         resolve(this);
       }, { once: true });
@@ -144,8 +127,6 @@ class TransportWs {
       ws.addEventListener('close', ({ code, reason, wasClean }) => {
         Logger.info(`${LOG_NS} ${this.name} websocket closed code=${code} reason=${reason} clean=${wasClean}`);
         /* Start cleanup */
-        /* Cancel the KA task */
-        this._unsetPingTask();
         const wasClosing = this._closing;
         this._closing = false;
         this._closed = true;
@@ -235,93 +216,6 @@ class TransportWs {
 
     /* Use internal helper */
     return this._attemptOpen();
-  }
-
-  /**
-   * Send a ws ping frame.
-   * This API is only available when the library is not used in a browser.
-   *
-   * @returns {Promise<void>}
-   */
-  async _ping() {
-    /* ws.ping is only supported on the node "ws" module */
-    if (typeof this._ws.ping !== 'function') {
-      Logger.warn('ws ping not supported');
-      return;
-    }
-    let timeout;
-
-    /* Set a promise that will reject in PING_TIME_WAIT_SECS seconds */
-    const timeout_ping = new Promise((_, reject) => {
-      timeout = setTimeout(_ => reject(new Error('timeout')), PING_TIME_WAIT_SECS * 1000);
-    });
-
-    /* Set a promise that will resolve once "pong" has been received */
-    const ping_op = new Promise((resolve, reject) => {
-      /* Send current timestamp in the ping */
-      const ping_data = '' + Date.now();
-
-      this._ws.ping(ping_data, error => {
-        if (error) {
-          Logger.error(`${LOG_NS} ${this.name} websocket PING send error (${error.message})`);
-          clearTimeout(timeout);
-          return reject(error);
-        }
-        Logger.verbose(`${LOG_NS} ${this.name} websocket PING sent (${ping_data})`);
-      });
-
-      /* Resolve on pong */
-      this._ws.once('pong', data => {
-        Logger.verbose(`${LOG_NS} ${this.name} websocket PONG received (${data.toString()})`);
-        clearTimeout(timeout);
-        return resolve();
-      });
-
-    });
-
-    /* Race between timeout and pong */
-    return Promise.race([ping_op, timeout_ping]);
-  }
-
-  /**
-   * Set a ws ping-pong task.
-   *
-   * @param {number} delay - The ping interval in milliseconds
-   * @returns {void}
-   */
-  _setPingTask(delay) {
-    /* ws "ping" is only supported on the node ws module */
-    if (typeof this._ws.ping !== 'function') {
-      Logger.warn('ws ping not supported');
-      return;
-    }
-    if (this._ping_task) return;
-
-    /* Set a periodic task to send a ping */
-    /* In case of error, terminate the ws */
-    this._ping_task = setInterval(async _ => {
-      try {
-        await this._ping();
-      } catch ({ message }) {
-        Logger.error(`${LOG_NS} ${this.name} websocket PING error (${message})`);
-        /* ws "terminate" is only supported on the node ws module */
-        this._ws.terminate();
-      }
-    }, delay);
-
-    Logger.info(`${LOG_NS} ${this.name} websocket ping task scheduled every ${PING_TIME_SECS} seconds`);
-  }
-
-  /**
-   * Remove the ws ping task.
-   *
-   * @returns {void}
-   */
-  _unsetPingTask() {
-    if (!this._ping_task) return;
-    clearInterval(this._ping_task);
-    this._ping_task = null;
-    Logger.info(`${LOG_NS} ${this.name} websocket ping task disabled`);
   }
 
   /**


### PR DESCRIPTION
Since runtime version 22.4.0, W3C WebSockets Client API is available on node.
We can switch to the native implementation, getting rid of two dependencies and some code that becomes useless.
There are a couple of downsides, though:
- Increase minimum runtime version to 22.4.0 (released on July 2024)
- Make impossible to send unsolicited ping frames from Janode (since this API is not exposed by the W3C specs)

This will need a minor version bump (e.g. 1.8.x).