### PR TITLE
streaming: add support for bufferkf_ms and bufferkf_bytes

### DIFF
--- a/src/plugins/streaming-plugin.js
+++ b/src/plugins/streaming-plugin.js
@@ -566,11 +566,13 @@ class StreamingHandle extends Handle {
    * @param {string} [params.video.rtpmap] - rtpmap that will be used
    * @param {boolean} [params.video.skew] - Set skew compensation
    * @param {string} [params.video.fmtp] - fmtp that will be used
-   * @param {boolean} [params.video.buffer] - Enable buffering of the keyframes
+   * @param {boolean} [params.video.buffer] - Enable buffering of the keyframes (deprecated, see bufferkf_ms and bufferkf_bytes)
    * @param {Object} [params.data] - The datachannel descriptor for the mp
    * @param {number} [params.data.port] - Port used for datachannels packets
    * @param {boolean} [params.data.buffer] - Enable buffering of the datachannels
    * @param {object[]} [params.media] - [multistream] The media object, each media includes type, mid, port, pt ...
+   * @param {number} [params.bufferkf_ms] - Enable buffering of the video keyframes (milliseconds)
+   * @param {number} [params.bufferkf_bytes] - Enable buffering of the video keyframes (bytes)
    * @param {number} [params.threads] - The number of helper threads used in this mp
    * @param {Object} [params.metadata] - An opaque metadata to add to the mp
    * @param {number} [params.collision] - The stream collision discarding time in number of milliseconds (0=disabled)

--- a/src/plugins/streaming-plugin.js
+++ b/src/plugins/streaming-plugin.js
@@ -576,7 +576,7 @@ class StreamingHandle extends Handle {
    * @param {number} [params.collision] - The stream collision discarding time in number of milliseconds (0=disabled)
    * @returns {Promise<module:streaming-plugin~STREAMING_EVENT_CREATED>}
    */
-  async createRtpMountpoint({ id = 0, name, description, secret, pin, admin_key, permanent = false, is_private = false, e2ee = false, audio, video, data, media, threads, metadata, collision }) {
+  async createRtpMountpoint({ id = 0, name, description, secret, pin, admin_key, permanent = false, is_private = false, e2ee = false, audio, video, data, media, bufferkf_ms, bufferkf_bytes, threads, metadata, collision }) {
     const body = {
       request: REQUEST_CREATE,
       type: 'rtp',
@@ -617,8 +617,6 @@ class StreamingHandle extends Handle {
         if (video.rtpmap) body.videortpmap = video.rtpmap;
         if (video.fmtp) body.videofmtp = video.fmtp;
         if (typeof video.buffer === 'boolean') body.videobufferkf = video.buffer;
-        if (typeof video.bufferkf_ms === 'number') body.bufferkf_ms = video.bufferkf_ms;
-        if (typeof video.bufferkf_bytes === 'number') body.bufferkf_bytes = video.bufferkf_bytes;
         if (typeof video.skew === 'boolean') body.videoskew = video.skew;
         if (typeof video.port2 === 'number' && typeof video.port3 === 'number') {
           body.videosimulcast = true;
@@ -632,6 +630,8 @@ class StreamingHandle extends Handle {
         if (typeof data.buffer === 'boolean') body.databuffermsg = data.buffer;
       }
     }
+    if (typeof bufferkf_ms === 'number') body.bufferkf_ms = bufferkf_ms;
+    if (typeof bufferkf_bytes === 'number') body.bufferkf_bytes = bufferkf_bytes;
     if (typeof threads === 'number' && threads > 0) body.threads = threads;
     if (metadata) body.metadata = metadata;
     if (typeof collision === 'number') body.collision = collision;

--- a/src/plugins/streaming-plugin.js
+++ b/src/plugins/streaming-plugin.js
@@ -617,6 +617,8 @@ class StreamingHandle extends Handle {
         if (video.rtpmap) body.videortpmap = video.rtpmap;
         if (video.fmtp) body.videofmtp = video.fmtp;
         if (typeof video.buffer === 'boolean') body.videobufferkf = video.buffer;
+        if (typeof video.bufferkf_ms === 'number') body.bufferkf_ms = video.bufferkf_ms;
+        if (typeof video.bufferkf_bytes === 'number') body.bufferkf_bytes = video.bufferkf_bytes;
         if (typeof video.skew === 'boolean') body.videoskew = video.skew;
         if (typeof video.port2 === 'number' && typeof video.port3 === 'number') {
           body.videosimulcast = true;


### PR DESCRIPTION
The Streaming plugin now supports configuring a keyframe buffer, in case a burst needs to be sent to new viewers to accelerate the time to first frame (check https://github.com/meetecho/janus-gateway/pull/3564 for more details). This PR makes the `createRtpMountpoint` method aware of the new properties. A simple example where we buffer 5 seconds of frames:

	await janodeManagerHandle.createRtpMountpoint({ id: 6464, name: 'bufferkf-test',
		bufferkf_ms: 5000, video: { port: 19004, pt: 96, rtpmap: 'H264/90000',
			fmtp: 'profile-level-id=42e01f;packetization-mode=1' } });
